### PR TITLE
Allows script to run from Paths with Spaces

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -81,7 +81,7 @@ define download_file(
   }
 
   exec { "download-${filename}":
-    command   => "${destination_directory}\\download-${powershell_filename}.ps1",
+    command   => "& '${destination_directory}\\download-${powershell_filename}.ps1'",
     provider  => powershell,
     onlyif    => "if(Test-Path -Path '${destination_directory}\\${filename}') { exit 1 } else { exit 0 }",
     logoutput => true,

--- a/spec/acceptance/download_file_spec.rb
+++ b/spec/acceptance/download_file_spec.rb
@@ -19,4 +19,23 @@ describe 'download_file' do
       it { should be_file }
     end
   end
+  
+  context 'with spaces in destination_directory path should still download dotnet 4' do
+    it 'should download dotnet 4' do
+
+      pp = <<-PP
+        download_file { "Download dotnet 4.0" :
+          url                   => 'http://download.microsoft.com/download/9/5/A/95A9616B-7A37-4AF6-BC36-D6EA96C8DAAE/dotNetFx40_Full_x86_x64.exe',
+          destination_directory => 'c:\\Program Files (x86)'
+        }
+      PP
+
+      apply_manifest(pp, :catch_failures => true)
+      expect(apply_manifest(pp, :catch_failures => true).exit_code).to be_zero
+    end
+
+    describe file("C:\\dotNetFx40_Full_x86_x64.exe") do
+      it { should be_file }
+    end
+  end
 end

--- a/spec/defines/download_file_spec.rb
+++ b/spec/defines/download_file_spec.rb
@@ -9,7 +9,7 @@ describe 'download_file', :type => :define do
     }}
 
     it { should contain_exec('download-test.exe').with({
-      'command' => "c:\\temp\\download-test.ps1",
+      'command' => "& 'c:\\temp\\download-test.ps1'",
       'onlyif'  => "if(Test-Path -Path 'c:\\temp\\test.exe') { exit 1 } else { exit 0 }",
     })}
   end
@@ -23,7 +23,7 @@ describe 'download_file', :type => :define do
     }}
 
     it { should contain_exec('download-test.exe').with({
-      'command' => "c:\\temp\\download-test.ps1",
+      'command' => "& 'c:\\temp\\download-test.ps1'",
       'onlyif'  => "if(Test-Path -Path 'c:\\temp\\test.exe') { exit 1 } else { exit 0 }",
     })}
   end
@@ -68,7 +68,7 @@ describe 'download_file', :type => :define do
     }}
 
     it { should contain_exec('download-test.exe').with({
-      'command' => "c:\\temp\\download-test.ps1",
+      'command' => "& 'c:\\temp\\download-test.ps1'",
       'onlyif'  => "if(Test-Path -Path 'c:\\temp\\test.exe') { exit 1 } else { exit 0 }",
     })}
   end
@@ -142,7 +142,7 @@ describe 'download_file', :type => :define do
     }}
 
     it { should contain_exec('download-test.msi').with({
-      'command' => "c:\\temp\\download-test.ps1",
+      'command' => "& 'c:\\temp\\download-test.ps1'",
       'onlyif'  => "if(Test-Path -Path 'c:\\temp\\test.msi') { exit 1 } else { exit 0 }",
     })}
   end
@@ -155,7 +155,7 @@ describe 'download_file', :type => :define do
     }}
 
     it { should contain_exec('download-nodejs-0.10.15-x64.msi').with({
-      'command' => "c:\\temp\\download-nodejs-0.10.15-x64.ps1",
+      'command' => "& 'c:\\temp\\download-nodejs-0.10.15-x64.ps1'",
       'onlyif'  => "if(Test-Path -Path 'c:\\temp\\nodejs-0.10.15-x64.msi') { exit 1 } else { exit 0 }",
     })}
   end
@@ -168,7 +168,7 @@ describe 'download_file', :type => :define do
     }}
 
     it { should contain_exec('download-test.exe').with({
-      'command' => "c:\\temp\\download-test.ps1",
+      'command' => "& 'c:\\temp\\download-test.ps1'",
       'onlyif'  => "if(Test-Path -Path 'c:\\temp\\test.exe') { exit 1 } else { exit 0 }",
     })}
   end
@@ -182,7 +182,7 @@ describe 'download_file', :type => :define do
     }}
 
     it { should contain_exec('download-foo.exe').with({
-      'command' => "c:\\temp\\download-test.ps1",
+      'command' => "& 'c:\\temp\\download-test.ps1'",
       'onlyif'  => "if(Test-Path -Path 'c:\\temp\\foo.exe') { exit 1 } else { exit 0 }",
     })}
   end


### PR DESCRIPTION
- Tiny Change to  exec["download-${filename}"] to allow download script to be run from paths with spaces
- Previously a script placed under /Program Files (x86)/ would fail to start because of the space in the path
- Adding quotes and an & at the beginning of the command will fix that. The "only if" already has quotes
