### PR TITLE
Proxy credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,34 @@ The optional name of the file to download onto the system.
 #####`proxy_address`
 The optional http proxy address to use when downloading the file
 
+#####`proxyUser`
+The optional http proxy user to use when downloading the file. `proxyAddress` and `proxyPassword`
+must be specified or this has no effect.
+
+#####`proxyPassword`
+The optional http proxy password to use when downloading the file. `proxyAddress` and `proxyUser`
+must be specified or this has no effect. By default this value accepts secure strings. A secure
+string is (unfortunately) tied to the machine that it is ued for. To generate a secure string for
+a given machine, users should run the following powershell command on that machine (replacing
+PASSWORD with the desired password):
+
+```Powershell
+ConvertFrom-SecureString -securestring $(ConvertTo-SecureString "PASSWORD" -AsPlainText -Force)
+```
+
+It is possible to get this information then clear the command from history, but it's important to
+note that the -Force argument is there to suppress warnings that the plaintext password is in
+the history.
+
+If this process sounds unappealing, you can send the password in plaintext (which sits in the
+download-<filename>.ps1 file on the machine being provisioned) by changing the `isPasswordSecure`
+variable to `false`.
+
+#####`isPasswordSecure`
+The optional switch to change the way that `proxyPassword` is interpreted from secure string to
+plaintext. This will send the password in plaintext to the machine being provisioned, which may
+be a security concern.
+
 ##Reference
 
 ###Defined Types
@@ -87,6 +115,8 @@ This module is tested on the following platforms:
 * Windows 2008 R2
 * Windows 2012
 * Windows 2012 R2
+* Windows 7
+* Windows 8
 
 It is tested with the OSS version of Puppet only.
 

--- a/README.md
+++ b/README.md
@@ -73,12 +73,12 @@ The optional name of the file to download onto the system.
 #####`proxy_address`
 The optional http proxy address to use when downloading the file
 
-#####`proxyUser`
-The optional http proxy user to use when downloading the file. `proxyAddress` and `proxyPassword`
+#####`proxy_user`
+The optional http proxy user to use when downloading the file. `proxy_address` and `proxy_password`
 must be specified or this has no effect.
 
-#####`proxyPassword`
-The optional http proxy password to use when downloading the file. `proxyAddress` and `proxyUser`
+#####`proxy_password`
+The optional http proxy password to use when downloading the file. `proxy_address` and `proxy_user`
 must be specified or this has no effect. By default this value accepts secure strings. A secure
 string is (unfortunately) tied to the machine that it is ued for. To generate a secure string for
 a given machine, users should run the following powershell command on that machine (replacing
@@ -93,10 +93,10 @@ note that the -Force argument is there to suppress warnings that the plaintext p
 the history.
 
 If this process sounds unappealing, you can send the password in plaintext (which sits in the
-download-<filename>.ps1 file on the machine being provisioned) by changing the `isPasswordSecure`
+download-<filename>.ps1 file on the machine being provisioned) by changing the `is_password_secure`
 variable to `false`.
 
-#####`isPasswordSecure`
+#####`is_password_secure`
 The optional switch to change the way that `proxyPassword` is interpreted from secure string to
 plaintext. This will send the password in plaintext to the machine being provisioned, which may
 be a security concern.

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 3. [Setup - The basics of getting started with download_file](#setup)
     * [What download_file affects](#what-download_file-affects)
     * [Setup requirements](#setup-requirements)
-    * [Beginning with download_file](#beginning-with-download_file)
+    * [Beginning with download_file](#beginning)
 4. [Usage - Configuration options and additional functionality](#usage)
 5. [Reference - An under-the-hood peek at what the module is doing and how](#reference)
 5. [Limitations - OS compatibility, etc.](#limitations)
-6. [Development - Guide for contributing to the module](#development)
+6. [Development - Guide for contributing to the module](#contributing)
 
 ##Overview
 The download_file module allows you to download files on Windows
@@ -80,7 +80,7 @@ must be specified or this has no effect.
 #####`proxy_password`
 The optional http proxy password to use when downloading the file. `proxy_address` and `proxy_user`
 must be specified or this has no effect. By default this value accepts secure strings. A secure
-string is (unfortunately) tied to the machine that it is ued for. To generate a secure string for
+string is (unfortunately) tied to the machine that it is used for. To generate a secure string for
 a given machine, users should run the following powershell command on that machine (replacing
 PASSWORD with the desired password):
 
@@ -105,7 +105,7 @@ be a security concern.
 
 ###Defined Types
 ####Public Types
-* [`download_file`](#defined-download_file): Download a give file
+* [`download_file`](#defined-type-download_file): Download a give file
 
 ##Limitations
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -52,6 +52,9 @@ define download_file(
   $destination_file = '',
   $proxyAddress=undef,
   $proxy_address=undef,
+  $proxyUser='',
+  $proxyPassword='',
+  $isPasswordSecure=true,
   $timeout = undef
 ) {
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,6 +25,15 @@
 # [*proxy_address*]
 # The optional http proxy address to use when downloading the file
 #
+# [*proxy_user*]
+# When using a proxy, the optional authentication user name.
+#
+# [*proxy_password*]
+# When using a proxy, the optional authentication password.
+#
+# [*is_password_secure*]
+# Boolean value. If true, proxy_password is assumed to be a securestring. Defaults to true.
+#
 # [*timeout*]
 # The optional timeout(in seconds) in case you expect to download big and slow file
 #
@@ -52,9 +61,9 @@ define download_file(
   $destination_file = '',
   $proxyAddress=undef,
   $proxy_address=undef,
-  $proxyUser='',
-  $proxyPassword='',
-  $isPasswordSecure=true,
+  $proxy_user='',
+  $proxy_password='',
+  $is_password_secure=true,
   $timeout = undef
 ) {
 
@@ -70,7 +79,6 @@ define download_file(
   }
 
   $powershell_filename = regsubst($url, '^(.*\/)(.+?)(?:\.[^\.]*$|$)$', '\2')
-
 
   if $proxyAddress {
     warning("${module_name}: The use of proxyAddress in Download_file[${title}] is deprecated. Use proxy_address instead.")

--- a/metadata.json
+++ b/metadata.json
@@ -11,7 +11,7 @@
   "operatingsystem_support": [
     {
       "operatingsystem":" windows",
-      "operatingsystemrelease": ["2008R2","2012","2012R2"]
+      "operatingsystemrelease": ["2008R2","2012","2012R2","7","8"]
     }
   ],
   "dependencies": [

--- a/spec/defines/download_file_spec.rb
+++ b/spec/defines/download_file_spec.rb
@@ -137,9 +137,9 @@ describe 'download_file', :type => :define do
     let(:params) {{
       :url => 'http://myserver.com/test.exe',
       :destination_directory => 'c:\temp',
-      :proxyAddress => 'test-proxy-01:8888',
-      :proxyUser => 'test-user',
-      :proxyPassword => 'test-secure'
+      :proxy_address => 'test-proxy-01:8888',
+      :proxy_user => 'test-user',
+      :proxy_password => 'test-secure'
     }}
     it { should contain_exec('download-test.exe').with({
       'command' => "c:\\temp\\download-test.ps1",
@@ -152,9 +152,9 @@ describe 'download_file', :type => :define do
     let(:params) {{
       :url => 'http://myserver.com/test.exe',
       :destination_directory => 'c:\temp',
-      :proxyAddress => 'test-proxy-01:8888',
-      :proxyUser => 'test-user',
-      :proxyPassword => 'test-secure'
+      :proxy_address => 'test-proxy-01:8888',
+      :proxy_user => 'test-user',
+      :proxy_password => 'test-secure'
     }}
 
     ps1 = <<-PS1.gsub(/^ {6}/, '')
@@ -201,10 +201,10 @@ describe 'download_file', :type => :define do
     let(:params) {{
       :url => 'http://myserver.com/test.exe',
       :destination_directory => 'c:\temp',
-      :proxyAddress => 'test-proxy-01:8888',
-      :proxyUser => 'test-user',
-      :proxyPassword => 'test',
-      :isPasswordSecure => false
+      :proxy_address => 'test-proxy-01:8888',
+      :proxy_user => 'test-user',
+      :proxy_password => 'test',
+      :is_password_secure => false
     }}
 
     it { should contain_exec('download-test.exe').with({
@@ -218,10 +218,10 @@ describe 'download_file', :type => :define do
     let(:params) {{
       :url => 'http://myserver.com/test.exe',
       :destination_directory => 'c:\temp',
-      :proxyAddress => 'test-proxy-01:8888',
-      :proxyUser => 'test-user',
-      :proxyPassword => 'test',
-      :isPasswordSecure => false
+      :proxy_address => 'test-proxy-01:8888',
+      :proxy_user => 'test-user',
+      :proxy_password => 'test',
+      :is_password_secure => false
     }}
 
     ps1 = <<-PS1.gsub(/^ {6}/, '')
@@ -388,13 +388,13 @@ describe 'download_file', :type => :define do
   describe 'the proxyAddress parameter' do
     let(:title)  { 'Download nodejs installer' }
     let(:params) {{
-        :url => 'http://my.server/test.exe',
-        :destination_directory => 'c:\temp',
-        :destination_file => 'foo.exe',
-        :proxyAddress => 'http://localhost:9090'
+      :url => 'http://my.server/test.exe',
+      :destination_directory => 'c:\temp',
+      :destination_file => 'foo.exe',
+      :proxyAddress => 'http://localhost:9090'
     }}
 
-    describe 'is still supported' do
+    describe 'is supported' do
       it {
         expect { should contain_exec('download-foo.exe') }.to_not raise_error
       }

--- a/spec/defines/download_file_spec.rb
+++ b/spec/defines/download_file_spec.rb
@@ -36,26 +36,27 @@ describe 'download_file', :type => :define do
       $webclient = New-Object System.Net.WebClient
       $proxyAddress = ''
       $proxyUser = ''
-      
-      
       $proxyPassword = ''
-      
-      
+
       if ($proxyAddress -ne '') {
-        if (!$proxyAddress.StartsWith('http://')) {
+        if (!($proxyAddress.StartsWith('http://') -or $proxyAddress.StartsWith('https://'))) {
           $proxyAddress = 'http://' + $proxyAddress
         }
-      
+
         $proxy = new-object System.Net.WebProxy
         $proxy.Address = $proxyAddress
         if (($proxyPassword -ne '') -and ($proxyUser -ne '')) {
+        
+          
           $password = ConvertTo-SecureString -string $proxyPassword
+          
+          
           $proxy.Credentials = New-Object System.Management.Automation.PSCredential($proxyUser, $password)
           $webclient.UseDefaultCredentials = $true
         }
         $webclient.proxy = $proxy
       }
-      
+
       try {
         $webclient.DownloadFile('http://myserver.com/test.exe', 'c:\\temp\\test.exe')
       }
@@ -96,26 +97,27 @@ describe 'download_file', :type => :define do
       $webclient = New-Object System.Net.WebClient
       $proxyAddress = 'test-proxy-01:8888'
       $proxyUser = ''
-      
-      
       $proxyPassword = ''
-      
-      
+
       if ($proxyAddress -ne '') {
-        if (!$proxyAddress.StartsWith('http://')) {
+        if (!($proxyAddress.StartsWith('http://') -or $proxyAddress.StartsWith('https://'))) {
           $proxyAddress = 'http://' + $proxyAddress
         }
-      
+
         $proxy = new-object System.Net.WebProxy
         $proxy.Address = $proxyAddress
         if (($proxyPassword -ne '') -and ($proxyUser -ne '')) {
+        
+          
           $password = ConvertTo-SecureString -string $proxyPassword
+          
+          
           $proxy.Credentials = New-Object System.Management.Automation.PSCredential($proxyUser, $password)
           $webclient.UseDefaultCredentials = $true
         }
         $webclient.proxy = $proxy
       }
-      
+
       try {
         $webclient.DownloadFile('http://myserver.com/test.exe', 'c:\\temp\\test.exe')
       }
@@ -139,7 +141,6 @@ describe 'download_file', :type => :define do
       :proxyUser => 'test-user',
       :proxyPassword => 'test-secure'
     }}
-
     it { should contain_exec('download-test.exe').with({
       'command' => "c:\\temp\\download-test.ps1",
       'onlyif'  => "if(Test-Path -Path 'c:\\temp\\test.exe') { exit 1 } else { exit 0 }",
@@ -160,26 +161,27 @@ describe 'download_file', :type => :define do
       $webclient = New-Object System.Net.WebClient
       $proxyAddress = 'test-proxy-01:8888'
       $proxyUser = 'test-user'
-      
-      
       $proxyPassword = 'test-secure'
-      
-      
+
       if ($proxyAddress -ne '') {
-        if (!$proxyAddress.StartsWith('http://')) {
+        if (!($proxyAddress.StartsWith('http://') -or $proxyAddress.StartsWith('https://'))) {
           $proxyAddress = 'http://' + $proxyAddress
         }
-      
+
         $proxy = new-object System.Net.WebProxy
         $proxy.Address = $proxyAddress
         if (($proxyPassword -ne '') -and ($proxyUser -ne '')) {
+        
+          
           $password = ConvertTo-SecureString -string $proxyPassword
+          
+          
           $proxy.Credentials = New-Object System.Management.Automation.PSCredential($proxyUser, $password)
           $webclient.UseDefaultCredentials = $true
         }
         $webclient.proxy = $proxy
       }
-      
+
       try {
         $webclient.DownloadFile('http://myserver.com/test.exe', 'c:\\temp\\test.exe')
       }
@@ -226,31 +228,27 @@ describe 'download_file', :type => :define do
       $webclient = New-Object System.Net.WebClient
       $proxyAddress = 'test-proxy-01:8888'
       $proxyUser = 'test-user'
-      
-      
-      if ('test' -ne '') - {
-        $proxyPassword = ConvertFrom-SecureString -securestring $(ConvertTo-SecureString "test" -AsPlainText -Force)
-      }
-      else {
-        $proxyPassword = ''
-      }
-      
-      
+      $proxyPassword = 'test'
+
       if ($proxyAddress -ne '') {
-        if (!$proxyAddress.StartsWith('http://')) {
+        if (!($proxyAddress.StartsWith('http://') -or $proxyAddress.StartsWith('https://'))) {
           $proxyAddress = 'http://' + $proxyAddress
         }
-      
+
         $proxy = new-object System.Net.WebProxy
         $proxy.Address = $proxyAddress
         if (($proxyPassword -ne '') -and ($proxyUser -ne '')) {
-          $password = ConvertTo-SecureString -string $proxyPassword
+        
+          
+          $password = ConvertTo-SecureString "$proxyPassword" -AsPlainText -Force
+          
+          
           $proxy.Credentials = New-Object System.Management.Automation.PSCredential($proxyUser, $password)
           $webclient.UseDefaultCredentials = $true
         }
         $webclient.proxy = $proxy
       }
-      
+
       try {
         $webclient.DownloadFile('http://myserver.com/test.exe', 'c:\\temp\\test.exe')
       }

--- a/spec/defines/download_file_spec.rb
+++ b/spec/defines/download_file_spec.rb
@@ -35,16 +35,27 @@ describe 'download_file', :type => :define do
     ps1 = <<-PS1.gsub(/^ {6}/, '')
       $webclient = New-Object System.Net.WebClient
       $proxyAddress = ''
+      $proxyUser = ''
+      
+      
+      $proxyPassword = ''
+      
+      
       if ($proxyAddress -ne '') {
         if (!$proxyAddress.StartsWith('http://')) {
           $proxyAddress = 'http://' + $proxyAddress
         }
-
+      
         $proxy = new-object System.Net.WebProxy
         $proxy.Address = $proxyAddress
+        if (($proxyPassword -ne '') -and ($proxyUser -ne '')) {
+          $password = ConvertTo-SecureString -string $proxyPassword
+          $proxy.Credentials = New-Object System.Management.Automation.PSCredential($proxyUser, $password)
+          $webclient.UseDefaultCredentials = $true
+        }
         $webclient.proxy = $proxy
       }
-
+      
       try {
         $webclient.DownloadFile('http://myserver.com/test.exe', 'c:\\temp\\test.exe')
       }
@@ -59,7 +70,7 @@ describe 'download_file', :type => :define do
     it { should contain_file('download-test.exe.ps1').with_content(ps1) }
   end
 
-  describe 'when downloading a file using a proxy server' do
+  describe 'when downloading a file using a proxy server without credentials' do
     let(:title)  { 'Download DotNet 4.0' }
     let(:params) {{
       :url => 'http://myserver.com/test.exe',
@@ -73,7 +84,7 @@ describe 'download_file', :type => :define do
     })}
   end
 
-  describe 'when downloading a file using a proxy server we want to check that the erb gets evaluated correctly' do
+  describe 'when downloading a file using a proxy server without credentials we want to check that the erb gets evaluated correctly' do
     let(:title)  { 'Download DotNet 4.0' }
     let(:params) {{
       :url => 'http://myserver.com/test.exe',
@@ -84,16 +95,162 @@ describe 'download_file', :type => :define do
     ps1 = <<-PS1.gsub(/^ {6}/, '')
       $webclient = New-Object System.Net.WebClient
       $proxyAddress = 'test-proxy-01:8888'
+      $proxyUser = ''
+      
+      
+      $proxyPassword = ''
+      
+      
       if ($proxyAddress -ne '') {
         if (!$proxyAddress.StartsWith('http://')) {
           $proxyAddress = 'http://' + $proxyAddress
         }
-
+      
         $proxy = new-object System.Net.WebProxy
         $proxy.Address = $proxyAddress
+        if (($proxyPassword -ne '') -and ($proxyUser -ne '')) {
+          $password = ConvertTo-SecureString -string $proxyPassword
+          $proxy.Credentials = New-Object System.Management.Automation.PSCredential($proxyUser, $password)
+          $webclient.UseDefaultCredentials = $true
+        }
         $webclient.proxy = $proxy
       }
+      
+      try {
+        $webclient.DownloadFile('http://myserver.com/test.exe', 'c:\\temp\\test.exe')
+      }
+      catch [Exception] {
+        write-host $_.Exception.GetType().FullName
+        write-host $_.Exception.Message
+        write-host $_.Exception.InnerException.Message
+        throw $_.Exception
+      }
+    PS1
 
+    it { should contain_file('download-test.exe.ps1').with_content(ps1) }
+	end
+
+  describe 'when downloading a file using a proxy server with credentials' do
+    let(:title)  { 'Download DotNet 4.0' }
+    let(:params) {{
+      :url => 'http://myserver.com/test.exe',
+      :destination_directory => 'c:\temp',
+      :proxyAddress => 'test-proxy-01:8888',
+      :proxyUser => 'test-user',
+      :proxyPassword => 'test-secure'
+    }}
+
+    it { should contain_exec('download-test.exe').with({
+      'command' => "c:\\temp\\download-test.ps1",
+      'onlyif'  => "if(Test-Path -Path 'c:\\temp\\test.exe') { exit 1 } else { exit 0 }",
+    })}
+  end
+
+  describe 'when downloading a file using a proxy server with secure credentials we want to check that the erb gets evaluated correctly' do
+    let(:title)  { 'Download DotNet 4.0' }
+    let(:params) {{
+      :url => 'http://myserver.com/test.exe',
+      :destination_directory => 'c:\temp',
+      :proxyAddress => 'test-proxy-01:8888',
+      :proxyUser => 'test-user',
+      :proxyPassword => 'test-secure'
+    }}
+
+    ps1 = <<-PS1.gsub(/^ {6}/, '')
+      $webclient = New-Object System.Net.WebClient
+      $proxyAddress = 'test-proxy-01:8888'
+      $proxyUser = 'test-user'
+      
+      
+      $proxyPassword = 'test-secure'
+      
+      
+      if ($proxyAddress -ne '') {
+        if (!$proxyAddress.StartsWith('http://')) {
+          $proxyAddress = 'http://' + $proxyAddress
+        }
+      
+        $proxy = new-object System.Net.WebProxy
+        $proxy.Address = $proxyAddress
+        if (($proxyPassword -ne '') -and ($proxyUser -ne '')) {
+          $password = ConvertTo-SecureString -string $proxyPassword
+          $proxy.Credentials = New-Object System.Management.Automation.PSCredential($proxyUser, $password)
+          $webclient.UseDefaultCredentials = $true
+        }
+        $webclient.proxy = $proxy
+      }
+      
+      try {
+        $webclient.DownloadFile('http://myserver.com/test.exe', 'c:\\temp\\test.exe')
+      }
+      catch [Exception] {
+        write-host $_.Exception.GetType().FullName
+        write-host $_.Exception.Message
+        write-host $_.Exception.InnerException.Message
+        throw $_.Exception
+      }
+    PS1
+
+    it { should contain_file('download-test.exe.ps1').with_content(ps1) }
+	end
+
+  describe 'when downloading a file using a proxy server with insecure credentials' do
+    let(:title)  { 'Download DotNet 4.0' }
+    let(:params) {{
+      :url => 'http://myserver.com/test.exe',
+      :destination_directory => 'c:\temp',
+      :proxyAddress => 'test-proxy-01:8888',
+      :proxyUser => 'test-user',
+      :proxyPassword => 'test',
+      :isPasswordSecure => false
+    }}
+
+    it { should contain_exec('download-test.exe').with({
+      'command' => "c:\\temp\\download-test.ps1",
+      'onlyif'  => "if(Test-Path -Path 'c:\\temp\\test.exe') { exit 1 } else { exit 0 }",
+    })}
+  end
+
+  describe 'when downloading a file using a proxy server with insecure credentials we want to check that the erb gets evaluated correctly' do
+    let(:title)  { 'Download DotNet 4.0' }
+    let(:params) {{
+      :url => 'http://myserver.com/test.exe',
+      :destination_directory => 'c:\temp',
+      :proxyAddress => 'test-proxy-01:8888',
+      :proxyUser => 'test-user',
+      :proxyPassword => 'test',
+      :isPasswordSecure => false
+    }}
+
+    ps1 = <<-PS1.gsub(/^ {6}/, '')
+      $webclient = New-Object System.Net.WebClient
+      $proxyAddress = 'test-proxy-01:8888'
+      $proxyUser = 'test-user'
+      
+      
+      if ('test' -ne '') - {
+        $proxyPassword = ConvertFrom-SecureString -securestring $(ConvertTo-SecureString "test" -AsPlainText -Force)
+      }
+      else {
+        $proxyPassword = ''
+      }
+      
+      
+      if ($proxyAddress -ne '') {
+        if (!$proxyAddress.StartsWith('http://')) {
+          $proxyAddress = 'http://' + $proxyAddress
+        }
+      
+        $proxy = new-object System.Net.WebProxy
+        $proxy.Address = $proxyAddress
+        if (($proxyPassword -ne '') -and ($proxyUser -ne '')) {
+          $password = ConvertTo-SecureString -string $proxyPassword
+          $proxy.Credentials = New-Object System.Management.Automation.PSCredential($proxyUser, $password)
+          $webclient.UseDefaultCredentials = $true
+        }
+        $webclient.proxy = $proxy
+      }
+      
       try {
         $webclient.DownloadFile('http://myserver.com/test.exe', 'c:\\temp\\test.exe')
       }

--- a/templates/download.ps1.erb
+++ b/templates/download.ps1.erb
@@ -1,27 +1,23 @@
 $webclient = New-Object System.Net.WebClient
 $proxyAddress = '<%= @proxy_address_real %>'
 $proxyUser = '<%= @proxyUser %>'
-
-<% if @isPasswordSecure %>
 $proxyPassword = '<%= @proxyPassword %>'
-<% else %>
-if ('<%= @proxyPassword %>' -ne '') - {
-  $proxyPassword = ConvertFrom-SecureString -securestring $(ConvertTo-SecureString "<%= @proxyPassword %>" -AsPlainText -Force)
-}
-else {
-  $proxyPassword = ''
-}
-<% end %>
 
 if ($proxyAddress -ne '') {
-  if (!$proxyAddress.StartsWith('http://')) {
+  if (!($proxyAddress.StartsWith('http://') -or $proxyAddress.StartsWith('https://'))) {
     $proxyAddress = 'http://' + $proxyAddress
   }
 
   $proxy = new-object System.Net.WebProxy
   $proxy.Address = $proxyAddress
   if (($proxyPassword -ne '') -and ($proxyUser -ne '')) {
+  
+    <% if @isPasswordSecure %>
     $password = ConvertTo-SecureString -string $proxyPassword
+    <% else %>
+    $password = ConvertTo-SecureString "$proxyPassword" -AsPlainText -Force
+    <% end %>
+    
     $proxy.Credentials = New-Object System.Management.Automation.PSCredential($proxyUser, $password)
     $webclient.UseDefaultCredentials = $true
   }

--- a/templates/download.ps1.erb
+++ b/templates/download.ps1.erb
@@ -1,5 +1,18 @@
 $webclient = New-Object System.Net.WebClient
 $proxyAddress = '<%= @proxy_address_real %>'
+$proxyUser = '<%= @proxyUser %>'
+
+<% if @isPasswordSecure %>
+$proxyPassword = '<%= @proxyPassword %>'
+<% else %>
+if ('<%= @proxyPassword %>' -ne '') - {
+  $proxyPassword = ConvertFrom-SecureString -securestring $(ConvertTo-SecureString "<%= @proxyPassword %>" -AsPlainText -Force)
+}
+else {
+  $proxyPassword = ''
+}
+<% end %>
+
 if ($proxyAddress -ne '') {
   if (!$proxyAddress.StartsWith('http://')) {
     $proxyAddress = 'http://' + $proxyAddress
@@ -7,6 +20,11 @@ if ($proxyAddress -ne '') {
 
   $proxy = new-object System.Net.WebProxy
   $proxy.Address = $proxyAddress
+  if (($proxyPassword -ne '') -and ($proxyUser -ne '')) {
+    $password = ConvertTo-SecureString -string $proxyPassword
+    $proxy.Credentials = New-Object System.Management.Automation.PSCredential($proxyUser, $password)
+    $webclient.UseDefaultCredentials = $true
+  }
   $webclient.proxy = $proxy
 }
 

--- a/templates/download.ps1.erb
+++ b/templates/download.ps1.erb
@@ -1,7 +1,7 @@
 $webclient = New-Object System.Net.WebClient
 $proxyAddress = '<%= @proxy_address_real %>'
-$proxyUser = '<%= @proxyUser %>'
-$proxyPassword = '<%= @proxyPassword %>'
+$proxyUser = '<%= @proxy_user %>'
+$proxyPassword = '<%= @proxy_password %>'
 
 if ($proxyAddress -ne '') {
   if (!($proxyAddress.StartsWith('http://') -or $proxyAddress.StartsWith('https://'))) {
@@ -12,7 +12,7 @@ if ($proxyAddress -ne '') {
   $proxy.Address = $proxyAddress
   if (($proxyPassword -ne '') -and ($proxyUser -ne '')) {
   
-    <% if @isPasswordSecure %>
+    <% if @is_password_secure %>
     $password = ConvertTo-SecureString -string $proxyPassword
     <% else %>
     $password = ConvertTo-SecureString "$proxyPassword" -AsPlainText -Force


### PR DESCRIPTION
Takes the changes from #16, rebased to master, and amends some UI changes and documentation changes.

Also, notably, I took this opportunity to deprecate the `proxyAddress` parameter in favor of `proxy_address`.