### PR TITLE
Sync metadata.json license to be same as LICENSE (MIT)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "name": "puppet-download_file",
   "version": "1.3.0",
   "author": "voxpupuli",
-  "license": "Apache-2.0",
+  "license": "MIT",
   "summary": "A module that will download files for use on Windows servers. Requires the server to have PowerShell 2.0 and above",
   "source": "https://github.com/voxpupuli/puppet-download_file",
   "project_page": "https://github.com/voxpupuli/puppet-download_file",


### PR DESCRIPTION
LICENSE file is MIT but metadata.json has had Apache-2.0 for quite
some time