### PR TITLE
Add cookie support

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ The optional switch to change the way that `proxyPassword` is interpreted from
 secure string to plaintext. This will send the password in plaintext to the
 machine being provisioned, which may be a security concern.
 
+#### `cookies`
+
+An optional array of cookies to add to the HTTP request for the download.
+
 ## Limitations
 
 This module is tested on the following platforms:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -67,7 +67,7 @@ define download_file(
   $proxy_password='',
   $is_password_secure=true,
   $timeout = undef,
-  $cookies = undef
+  Optional[Array[String]] $cookies = undef
 ) {
 
   if "x${destination_file}x" == 'xx' {
@@ -82,7 +82,6 @@ define download_file(
   }
 
   if $cookies {
-    validate_array($cookies)
     $cookie_string = join($cookies, ';')
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,7 +63,8 @@ define download_file(
   $proxy_user='',
   $proxy_password='',
   $is_password_secure=true,
-  $timeout = undef
+  $timeout = undef,
+  $cookies = undef
 ) {
 
   if "x${destination_file}x" == 'xx' {
@@ -75,6 +76,11 @@ define download_file(
   if $timeout {
     validate_integer($timeout)
     Exec { timeout => $timeout }
+  }
+
+  if $cookies {
+    validate_array($cookies)
+    $cookie_string = join($cookies, ';')
   }
 
   $powershell_filename = regsubst($url, '^(.*\/)(.+?)(?:\.[^\.]*$|$)$', '\2')

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,6 +37,9 @@
 # [*timeout*]
 # The optional timeout(in seconds) in case you expect to download big and slow file
 #
+# [*cookies*]
+# An optional array of cookies to add to the HTTP request for the download.
+#
 # === Examples
 #
 # To download dotnet 4.0

--- a/spec/defines/download_file_spec.rb
+++ b/spec/defines/download_file_spec.rb
@@ -292,6 +292,57 @@ describe 'download_file', type: :define do
     it { is_expected.to contain_file('download-test.exe.ps1').with_content(ps1) }
   end
 
+  describe 'when downloading a file with provided cookies we want to check that the erb gets evaluated correctly' do
+    let(:title)  { 'Download DotNet 4.0' }
+    let(:params) do
+      {
+        url: 'http://myserver.com/test.exe',
+        destination_directory: 'c:\temp',
+        cookies: ['my_cookie=something-secure', 'this_too=something-else']
+      }
+    end
+
+    ps1 = <<-PS1.gsub(%r{^ {6}}, '')
+      $webclient = New-Object System.Net.WebClient
+      $proxyAddress = ''
+      $proxyUser = ''
+      $proxyPassword = ''
+
+      if ($proxyAddress -ne '') {
+        if (!($proxyAddress.StartsWith('http://') -or $proxyAddress.StartsWith('https://'))) {
+          $proxyAddress = 'http://' + $proxyAddress
+        }
+
+        $proxy = new-object System.Net.WebProxy
+        $proxy.Address = $proxyAddress
+        if (($proxyPassword -ne '') -and ($proxyUser -ne '')) {
+        
+          
+          $password = ConvertTo-SecureString -string $proxyPassword
+          
+          
+          $proxy.Credentials = New-Object System.Management.Automation.PSCredential($proxyUser, $password)
+          $webclient.UseDefaultCredentials = $true
+        }
+        $webclient.proxy = $proxy
+      }
+
+      $webclient.Headers.Add([System.Net.HttpRequestHeader]::Cookie, "my_cookie=something-secure;this_too=something-else")
+
+      try {
+        $webclient.DownloadFile('http://myserver.com/test.exe', 'c:\\temp\\test.exe')
+      }
+      catch [Exception] {
+        write-host $_.Exception.GetType().FullName
+        write-host $_.Exception.Message
+        write-host $_.Exception.InnerException.Message
+        throw $_.Exception
+      }
+    PS1
+
+    it { is_expected.to contain_file('download-test.exe.ps1').with_content(ps1) }
+  end
+
   describe 'when not passing a destination url to the download define' do
     let(:title)  { 'Download DotNet 4.0' }
     let(:params) do 

--- a/templates/download.ps1.erb
+++ b/templates/download.ps1.erb
@@ -23,7 +23,9 @@ if ($proxyAddress -ne '') {
   }
   $webclient.proxy = $proxy
 }
-
+<% if @cookies %>
+<%= '$webclient.Headers.Add([System.Net.HttpRequestHeader]::Cookie, "' + @cookie_string + '")' %>
+<% end %>
 try {
   $webclient.DownloadFile('<%= @url %>', '<%= @destination_directory %>\<%= @filename %>')
 }


### PR DESCRIPTION
Hey there,

This adds support for setting cookies in the HTTP request for the download.

For example, you can download the Java JDK installer from Oracle like so:

```puppet
  download_file { 'Download JDK' :
    url                   => 'http://download.oracle.com/otn-pub/java/jdk/8u121-b13/e9e7ea248e2c4826b92b3f075a80e441/jdk-8u121-windows-x64.exe',
    destination_directory => 'c:\temp',
    cookies               => ['oraclelicense=accept-securebackup-cookie', 'gpw_e24=http://edelivery.oracle.com'],
  }
```