### PR TITLE
Fix error duplicate resource when url has same ending

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -84,16 +84,16 @@ define download_file(
     $cookie_string = join($cookies, ';')
   }
 
-  $powershell_filename = regsubst($url, '^(.*\/)(.+?)(?:\.[^\.]*$|$)$', '\2')
+  $file_path = "${destination_directory}\\download-${filename}.ps1"
 
   file { "download-${filename}.ps1":
     ensure  => present,
-    path    => "${destination_directory}\\download-${powershell_filename}.ps1",
+    path    => $file_path,
     content => template('download_file/download.ps1.erb'),
   }
 
   exec { "download-${filename}":
-    command   => "${destination_directory}\\download-${powershell_filename}.ps1",
+    command   => $file_path,
     provider  => powershell,
     onlyif    => "if(Test-Path -Path '${destination_directory}\\${filename}') { exit 1 } else { exit 0 }",
     logoutput => true,

--- a/spec/defines/download_file_spec.rb
+++ b/spec/defines/download_file_spec.rb
@@ -15,7 +15,7 @@ describe 'download_file', type: :define do
 
     it do 
       is_expected.to contain_exec('download-test.exe').with(
-        'command' => 'c:\\temp\\download-test.ps1',
+        'command' => 'c:\\temp\\download-test.exe.ps1',
         'onlyif'  => "if(Test-Path -Path 'c:\\temp\\test.exe') { exit 1 } else { exit 0 }"
       )
     end
@@ -33,7 +33,7 @@ describe 'download_file', type: :define do
 
     it do 
       is_expected.to contain_exec('download-test.exe').with(
-        'command' => 'c:\\temp\\download-test.ps1',
+        'command' => 'c:\\temp\\download-test.exe.ps1',
         'onlyif'  => "if(Test-Path -Path 'c:\\temp\\test.exe') { exit 1 } else { exit 0 }"
       )
     end
@@ -94,7 +94,7 @@ describe 'download_file', type: :define do
 
     it do 
       is_expected.to contain_exec('download-test.exe').with(
-        'command' => 'c:\\temp\\download-test.ps1',
+        'command' => 'c:\\temp\\download-test.exe.ps1',
         'onlyif'  => "if(Test-Path -Path 'c:\\temp\\test.exe') { exit 1 } else { exit 0 }"
       )
     end
@@ -163,7 +163,7 @@ describe 'download_file', type: :define do
 
     it do 
       is_expected.to contain_exec('download-test.exe').with(
-        'command' => 'c:\\temp\\download-test.ps1',
+        'command' => 'c:\\temp\\download-test.exe.ps1',
         'onlyif' => "if(Test-Path -Path 'c:\\temp\\test.exe') { exit 1 } else { exit 0 }"
       )
     end
@@ -235,7 +235,7 @@ describe 'download_file', type: :define do
 
     it do 
       is_expected.to contain_exec('download-test.exe').with(
-        'command' => 'c:\\temp\\download-test.ps1',
+        'command' => 'c:\\temp\\download-test.exe.ps1',
         'onlyif' => "if(Test-Path -Path 'c:\\temp\\test.exe') { exit 1 } else { exit 0 }"
       )
     end
@@ -385,7 +385,7 @@ describe 'download_file', type: :define do
 
     it do 
       is_expected.to contain_exec('download-test.msi').with(
-        'command' => 'c:\\temp\\download-test.ps1',
+        'command' => 'c:\\temp\\download-test.msi.ps1',
         'onlyif'  => "if(Test-Path -Path 'c:\\temp\\test.msi') { exit 1 } else { exit 0 }"
       )
     end
@@ -402,7 +402,7 @@ describe 'download_file', type: :define do
 
     it do 
       is_expected.to contain_exec('download-nodejs-0.10.15-x64.msi').with(
-        'command' => 'c:\\temp\\download-nodejs-0.10.15-x64.ps1',
+        'command' => 'c:\\temp\\download-nodejs-0.10.15-x64.msi.ps1',
         'onlyif'  => "if(Test-Path -Path 'c:\\temp\\nodejs-0.10.15-x64.msi') { exit 1 } else { exit 0 }"
       )
     end
@@ -419,7 +419,7 @@ describe 'download_file', type: :define do
 
     it do 
       is_expected.to contain_exec('download-test.exe').with(
-        'command' => 'c:\\temp\\download-test.ps1',
+        'command' => 'c:\\temp\\download-test.exe.ps1',
         'onlyif'  => "if(Test-Path -Path 'c:\\temp\\test.exe') { exit 1 } else { exit 0 }"
       )
     end
@@ -437,7 +437,7 @@ describe 'download_file', type: :define do
 
     it do 
       is_expected.to contain_exec('download-foo.exe').with(
-        'command' => 'c:\\temp\\download-test.ps1',
+        'command' => 'c:\\temp\\download-foo.exe.ps1',
         'onlyif'  => "if(Test-Path -Path 'c:\\temp\\foo.exe') { exit 1 } else { exit 0 }"
       )
     end


### PR DESCRIPTION
Using this definition:

```
    download_file { 'test1':
      url                   => 'https://download.microsoft.com/XXX/SQL13/amd64/SQLSysClrTypes.msi',
      destination_directory => $destination_directory,
      destination_file      => $destination_file,
      require               => File[$destination_file],
    }

    download_file { 'test2':
      url                   => 'https://download.microsoft.com/XXX/SQL13/x86/SQLSysClrTypes.msi',
      destination_directory => $destination_directory,
      destination_file      => $destination_file,
      require               => File[$destination_file],
    }
```
I got this error: 
`resource ["File", "C:\\Temp\\SQLSysClrTypes\\download-SQLSysClrTypes.ps1"] already declared at 
/etc/puppetlabs/code/modules/download_file/manifests/init.pp:89`

The problem is due to this variable definition:
`$powershell_filename = regsubst($url, '^(.*\/)(.+?)(?:\.[^\.]*$|$)$', '\2')`
As you can see the `regsubst` grabs this part of the url `SQLSysClrTypes` and that part of the url is the same for both of them, as a result the path value in the file definition will give a duplicate resource.
```
file { "download-${filename}.ps1":
    ensure  => present,
    path    => "${destination_directory}\\download-${powershell_filename}.ps1",
    content => template('download_file/download.ps1.erb'),
  }
```
