### PR TITLE
Enable TLSv1.2 downloads

### DIFF
--- a/spec/defines/download_file_spec.rb
+++ b/spec/defines/download_file_spec.rb
@@ -49,6 +49,8 @@ describe 'download_file', type: :define do
       $proxyUser = ''
       $proxyPassword = ''
 
+      [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls10 -bor [Net.SecurityProtocolType]::Tls11 -bor [Net.    SecurityProtocolType]::Tls12
+
       if ($proxyAddress -ne '') {
         if (!($proxyAddress.StartsWith('http://') -or $proxyAddress.StartsWith('https://'))) {
           $proxyAddress = 'http://' + $proxyAddress

--- a/spec/defines/download_file_spec.rb
+++ b/spec/defines/download_file_spec.rb
@@ -49,7 +49,7 @@ describe 'download_file', type: :define do
       $proxyUser = ''
       $proxyPassword = ''
 
-      [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls10 -bor [Net.SecurityProtocolType]::Tls11 -bor [Net.    SecurityProtocolType]::Tls12
+      [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls10 -bor [Net.SecurityProtocolType]::Tls11 -bor [Net.SecurityProtocolType]::Tls12
 
       if ($proxyAddress -ne '') {
         if (!($proxyAddress.StartsWith('http://') -or $proxyAddress.StartsWith('https://'))) {

--- a/templates/download.ps1.erb
+++ b/templates/download.ps1.erb
@@ -3,6 +3,8 @@ $proxyAddress = '<%= @proxy_address %>'
 $proxyUser = '<%= @proxy_user %>'
 $proxyPassword = '<%= @proxy_password %>'
 
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls10 -bor [Net.SecurityProtocolType]::Tls11 -bor [Net.SecurityProtocolType]::Tls12 
+
 if ($proxyAddress -ne '') {
   if (!($proxyAddress.StartsWith('http://') -or $proxyAddress.StartsWith('https://'))) {
     $proxyAddress = 'http://' + $proxyAddress


### PR DESCRIPTION
The download_file module does not support TLSv1.2. This breaks sites (such as Github) which are TLSv1.2 only. This PR enables TLSv1.2 but can fallback to v1.1 and v1.0.
