### PR TITLE
Enable TLSv1.2; fallback to TLSv1.1 and 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,13 @@ machine being provisioned, which may be a security concern.
 
 An optional array of cookies to add to the HTTP request for the download.
 
+#### `allow_insecure_ssl`
+
+Permits the use of sslv3 HTTPS connections. If this is set to false, only TLSv1, TLSv1.1
+and TLSv1.2 are permitted.
+
+Defaults to true.
+
 ## Limitations
 
 This module is tested on the following platforms:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,6 +43,9 @@
 # [*user_agent*]
 # The optional user agent string to be sent when downloading.
 #
+# [*allow_insecure_ssl*]
+# Allow sslv3 in addition to TLS version for HTTPS connections. Defaults to true.
+#
 # === Examples
 #
 # To download dotnet 4.0
@@ -64,14 +67,15 @@
 define download_file(
   Stdlib::HTTPUrl $url,
   String $destination_directory,
-  Optional[String] $destination_file = undef,
-  $proxy_address                     = undef,
-  $proxy_user                        = '',
-  $proxy_password                    = '',
-  $is_password_secure                = true,
-  Optional[Integer] $timeout         = undef,
-  Optional[Array[String]] $cookies   = undef,
-  Optional[String] $user_agent       = undef
+  Optional[String] $destination_file    = undef,
+  $proxy_address                        = undef,
+  $proxy_user                           = '',
+  $proxy_password                       = '',
+  $is_password_secure                   = true,
+  Optional[Integer] $timeout            = undef,
+  Optional[Array[String]] $cookies      = undef,
+  Optional[String] $user_agent          = undef,
+  Optional[Boolean] $allow_insecure_ssl = true
 ) {
 
   if $destination_file {

--- a/spec/defines/download_file_spec.rb
+++ b/spec/defines/download_file_spec.rb
@@ -50,6 +50,9 @@ describe 'download_file', type: :define do
       $proxyPassword = ''
 
 
+      [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Ssl3 -bor [Net.SecurityProtocolType]::Tls10 -bor [Net.SecurityProtocolType]::Tls11 -bor [Net.SecurityProtocolType]::Tls12
+
+
       if ($proxyAddress -ne '') {
         if (!($proxyAddress.StartsWith('http://') -or $proxyAddress.StartsWith('https://'))) {
           $proxyAddress = 'http://' + $proxyAddress
@@ -116,6 +119,9 @@ describe 'download_file', type: :define do
       $proxyAddress = 'test-proxy-01:8888'
       $proxyUser = ''
       $proxyPassword = ''
+
+
+      [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Ssl3 -bor [Net.SecurityProtocolType]::Tls10 -bor [Net.SecurityProtocolType]::Tls11 -bor [Net.SecurityProtocolType]::Tls12
 
 
       if ($proxyAddress -ne '') {
@@ -188,6 +194,9 @@ describe 'download_file', type: :define do
       $proxyAddress = 'test-proxy-01:8888'
       $proxyUser = 'test-user'
       $proxyPassword = 'test-secure'
+
+
+      [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Ssl3 -bor [Net.SecurityProtocolType]::Tls10 -bor [Net.SecurityProtocolType]::Tls11 -bor [Net.SecurityProtocolType]::Tls12
 
 
       if ($proxyAddress -ne '') {
@@ -264,6 +273,9 @@ describe 'download_file', type: :define do
       $proxyPassword = 'test'
 
 
+      [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Ssl3 -bor [Net.SecurityProtocolType]::Tls10 -bor [Net.SecurityProtocolType]::Tls11 -bor [Net.SecurityProtocolType]::Tls12
+
+
       if ($proxyAddress -ne '') {
         if (!($proxyAddress.StartsWith('http://') -or $proxyAddress.StartsWith('https://'))) {
           $proxyAddress = 'http://' + $proxyAddress
@@ -272,11 +284,11 @@ describe 'download_file', type: :define do
         $proxy = new-object System.Net.WebProxy
         $proxy.Address = $proxyAddress
         if (($proxyPassword -ne '') -and ($proxyUser -ne '')) {
-        
-          
+
+
           $password = ConvertTo-SecureString "$proxyPassword" -AsPlainText -Force
-          
-          
+
+
           $proxy.Credentials = New-Object System.Management.Automation.PSCredential($proxyUser, $password)
           $webclient.UseDefaultCredentials = $true
         }
@@ -314,6 +326,64 @@ describe 'download_file', type: :define do
       $proxyPassword = ''
 
 
+      [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Ssl3 -bor [Net.SecurityProtocolType]::Tls10 -bor [Net.SecurityProtocolType]::Tls11 -bor [Net.SecurityProtocolType]::Tls12
+
+
+      if ($proxyAddress -ne '') {
+        if (!($proxyAddress.StartsWith('http://') -or $proxyAddress.StartsWith('https://'))) {
+          $proxyAddress = 'http://' + $proxyAddress
+        }
+
+        $proxy = new-object System.Net.WebProxy
+        $proxy.Address = $proxyAddress
+        if (($proxyPassword -ne '') -and ($proxyUser -ne '')) {
+
+
+          $password = ConvertTo-SecureString -string $proxyPassword
+
+
+          $proxy.Credentials = New-Object System.Management.Automation.PSCredential($proxyUser, $password)
+          $webclient.UseDefaultCredentials = $true
+        }
+        $webclient.proxy = $proxy
+      }
+
+      $webclient.Headers.Add([System.Net.HttpRequestHeader]::Cookie, "my_cookie=something-secure;this_too=something-else")
+
+      try {
+        $webclient.DownloadFile('http://myserver.com/test.exe', 'c:\\temp\\test.exe')
+      }
+      catch [Exception] {
+        write-host $_.Exception.GetType().FullName
+        write-host $_.Exception.Message
+        write-host $_.Exception.InnerException.Message
+        throw $_.Exception
+      }
+    PS1
+
+    it { is_expected.to contain_file('download-test.exe.ps1').with_content(ps1) }
+  end
+
+  describe 'when downloading a file with allow_insecure_ssl false we want to check that the erb gets evaluated correctly' do
+    let(:title)  { 'Download DotNet 4.0' }
+    let(:params) do
+      {
+        url: 'http://myserver.com/test.exe',
+        destination_directory: 'c:\temp',
+        allow_insecure_ssl: false
+      }
+    end
+
+    ps1 = <<-PS1.gsub(%r{^ {6}}, '')
+      $webclient = New-Object System.Net.WebClient
+      $proxyAddress = ''
+      $proxyUser = ''
+      $proxyPassword = ''
+
+
+      [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls10 -bor [Net.SecurityProtocolType]::Tls11 -bor [Net.SecurityProtocolType]::Tls12
+
+
       if ($proxyAddress -ne '') {
         if (!($proxyAddress.StartsWith('http://') -or $proxyAddress.StartsWith('https://'))) {
           $proxyAddress = 'http://' + $proxyAddress
@@ -332,8 +402,6 @@ describe 'download_file', type: :define do
         }
         $webclient.proxy = $proxy
       }
-
-      $webclient.Headers.Add([System.Net.HttpRequestHeader]::Cookie, "my_cookie=something-secure;this_too=something-else")
 
       try {
         $webclient.DownloadFile('http://myserver.com/test.exe', 'c:\\temp\\test.exe')

--- a/templates/download.ps1.erb
+++ b/templates/download.ps1.erb
@@ -5,6 +5,11 @@ $proxyPassword = '<%= @proxy_password %>'
 <% if @user_agent %>
 $webclient.Headers['User-Agent'] = '<%= @user_agent %>'
 <% end %>
+<% if @allow_insecure_ssl %>
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Ssl3 -bor [Net.SecurityProtocolType]::Tls10 -bor [Net.SecurityProtocolType]::Tls11 -bor [Net.SecurityProtocolType]::Tls12
+<% else %>
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls10 -bor [Net.SecurityProtocolType]::Tls11 -bor [Net.SecurityProtocolType]::Tls12
+<% end %>
 
 if ($proxyAddress -ne '') {
   if (!($proxyAddress.StartsWith('http://') -or $proxyAddress.StartsWith('https://'))) {


### PR DESCRIPTION
This is a rebase of https://github.com/voxpupuli/puppet-download_file/pull/68