### PR TITLE
Allow enabled SSL protocols to be specified

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -71,7 +71,7 @@ define download_file(
   $proxy_user                        = '',
   $proxy_password                    = '',
   $is_password_secure                = true,
-  Optional[Enum['ssl3', 'tls', 'tls11', 'tls12', 'tls13']] 
+  Optional[Enum['ssl3', 'tls', 'tls11', 'tls12', 'tls13']]
   $security_protocol                 = undef,
   Optional[Integer] $timeout         = undef,
   Optional[Array[String]] $cookies   = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -71,6 +71,8 @@ define download_file(
   $proxy_user                        = '',
   $proxy_password                    = '',
   $is_password_secure                = true,
+  Optional[Enum['ssl3', 'tls', 'tls11', 'tls12', 'tls13']] 
+  $security_protocol                 = undef,
   Optional[Integer] $timeout         = undef,
   Optional[Array[String]] $cookies   = undef,
   Optional[String] $user_agent       = undef

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -64,18 +64,17 @@
 define download_file(
   Stdlib::HTTPUrl $url,
   String $destination_directory,
-  Optional[String] $destination_file = undef,
-  $proxy_address                     = undef,
-  $user                              = '',
-  $password                          = '',
-  $proxy_user                        = '',
-  $proxy_password                    = '',
-  $is_password_secure                = true,
-  Optional[Enum['ssl3', 'tls', 'tls11', 'tls12', 'tls13']]
-  $security_protocol                 = undef,
-  Optional[Integer] $timeout         = undef,
-  Optional[Array[String]] $cookies   = undef,
-  Optional[String] $user_agent       = undef
+  Optional[String] $destination_file                                          = undef,
+  $proxy_address                                                              = undef,
+  $user                                                                       = '',
+  $password                                                                   = '',
+  $proxy_user                                                                 = '',
+  $proxy_password                                                             = '',
+  $is_password_secure                                                         = true,
+  Optional[Enum['ssl3', 'tls', 'tls11', 'tls12', 'tls13']] $security_protocol = undef,
+  Optional[Integer] $timeout                                                  = undef,
+  Optional[Array[String]] $cookies                                            = undef,
+  Optional[String] $user_agent                                                = undef
 ) {
 
   if $destination_file {

--- a/templates/download.ps1.erb
+++ b/templates/download.ps1.erb
@@ -1,9 +1,7 @@
-
-<% if @security_protocol %>
+<% if @security_protocol -%>
 [Net.ServicePointManager]::Expect100Continue = 'true';
 [Net.ServicePointManager]::SecurityProtocol = '<%= @security_protocol %>';
-<% end %>
-
+<% end -%>
 $webclient = New-Object System.Net.WebClient
 $user = '<%= @user %>'
 $password = '<%= @password %>'

--- a/templates/download.ps1.erb
+++ b/templates/download.ps1.erb
@@ -1,7 +1,7 @@
 
-<% if @enable_protocols %>
+<% if @security_protocol %>
 [Net.ServicePointManager]::Expect100Continue = 'true';
-[Net.ServicePointManager]::SecurityProtocol = 'Tls' | 'Tls11' | 'Tls12' | 'Ssl3';
+[Net.ServicePointManager]::SecurityProtocol = '<%= @security_protocol %>';
 <% end %>
 
 $webclient = New-Object System.Net.WebClient

--- a/templates/download.ps1.erb
+++ b/templates/download.ps1.erb
@@ -1,3 +1,9 @@
+
+<% if @enable_protocols %>
+[Net.ServicePointManager]::Expect100Continue = 'true';
+[Net.ServicePointManager]::SecurityProtocol = 'Tls' | 'Tls11' | 'Tls12' | 'Ssl3';
+<% end %>
+
 $webclient = New-Object System.Net.WebClient
 $user = '<%= @user %>'
 $password = '<%= @password %>'


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

When using download_file on some Windows systems against files on GitHub, I received:

+ FullyQualifiedErrorId : The request was aborted: Could not create SSL/TLS secure channel.

It appears that system didn't have all the SSL protocols enabled on group policy level, which I cannot change at the moment.

This pull request creates a workaround allowing to specify which protocol to use when downloading files.

Example:

      download_file { 'Download git':
        url                   => 'https://github.com/git-for-windows/git/releases/download/v2.19.2.windows.1/Git-2.19.2-64-bit.exe',
        security_protocol     => 'tls12',
        destination_directory => 'C:/software',
      }

